### PR TITLE
Wait group to be more confident when stopping

### DIFF
--- a/client.go
+++ b/client.go
@@ -42,8 +42,9 @@ var (
 )
 
 // NewClient returns a client that can send data to a bucky server
-// It takes an interval value in seconds
-func NewClient(host string, interval int) (cl *Client, err error) {
+// It takes an interval value in seconds, and chanCapacity for the capacity
+// of the input channel
+func NewClient(host string, interval int, chanCapacity int) (cl *Client, err error) {
 
 	// We should never send more often than once per minute
 	if interval < 60 {
@@ -63,7 +64,7 @@ func NewClient(host string, interval int) (cl *Client, err error) {
 		http:       &http.Client{},
 		logger:     log.New(os.Stderr, "", log.Ldate|log.Ltime|log.Lshortfile),
 		interval:   intDur,
-		input:      make(chan MetricWithAmount, 100),
+		input:      make(chan MetricWithAmount, chanCapacity),
 		stop:       make(chan bool, 1),
 		stopped:    make(chan bool, 1),
 		metrics:    make(map[Metric]Value),

--- a/client_test.go
+++ b/client_test.go
@@ -36,7 +36,7 @@ func mockBuckyServer(code int) *httptest.Server {
 }
 
 func TestClient_Client_NewClient(t *testing.T) {
-	cl, err := NewClient("", 20)
+	cl, err := NewClient("", 20, 0)
 	defer func() {
 		close(cl.stop)
 		close(cl.stopped)
@@ -48,7 +48,7 @@ func TestClient_Client_NewClient(t *testing.T) {
 }
 
 func TestClient_Client_NewClient_Error(t *testing.T) {
-	cl, err := NewClient("", 1<<48) // Cause an integer overflow in time.ParseDuration
+	cl, err := NewClient("", 1<<48, 0) // Cause an integer overflow in time.ParseDuration
 
 	assert.Error(t, err)
 	assert.Nil(t, cl)

--- a/client_test.go
+++ b/client_test.go
@@ -1,8 +1,6 @@
 package buckyclient
 
 import (
-	// "errors"
-
 	"bytes"
 	"fmt"
 	"io"
@@ -11,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -68,6 +67,7 @@ func TestClient_Client_Count(t *testing.T) {
 		stopped:    make(chan bool, 1),
 		metrics:    make(map[Metric]Value),
 		bufferPool: newBufferPool(),
+		waitGroup:  &sync.WaitGroup{},
 	}
 	defer func() {
 		close(cl.stop)
@@ -101,6 +101,7 @@ func TestClient_Client_Timer(t *testing.T) {
 		stopped:    make(chan bool, 1),
 		metrics:    make(map[Metric]Value),
 		bufferPool: newBufferPool(),
+		waitGroup:  &sync.WaitGroup{},
 	}
 	defer func() {
 		close(cl.stop)
@@ -134,6 +135,7 @@ func TestClient_Client_AverageTimer(t *testing.T) {
 		stopped:    make(chan bool, 1),
 		metrics:    make(map[Metric]Value),
 		bufferPool: newBufferPool(),
+		waitGroup:  &sync.WaitGroup{},
 	}
 	defer func() {
 		close(cl.stop)
@@ -404,9 +406,10 @@ func TestClient_Client_Stop(t *testing.T) {
 	buf := &bytes.Buffer{}
 
 	cl := &Client{
-		logger:  log.New(buf, "", log.Ldate|log.Ltime|log.Lshortfile),
-		stop:    make(chan bool, 1),
-		stopped: make(chan bool, 1),
+		logger:    log.New(buf, "", log.Ldate|log.Ltime|log.Lshortfile),
+		stop:      make(chan bool, 1),
+		stopped:   make(chan bool, 1),
+		waitGroup: &sync.WaitGroup{},
 	}
 
 	go func() {

--- a/example/main.go
+++ b/example/main.go
@@ -29,7 +29,7 @@ func main() {
 
 	}()
 
-	bc, err := buckyclient.NewClient("http://localhost:8005/bucky/v1/send", 1)
+	bc, err := buckyclient.NewClient("http://localhost:8005/bucky/v1/send", 1, 100)
 
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
This way we can be sure that we don't have goroutines which have started, but haven't written to the input channel yet. And then we might lose those events.
